### PR TITLE
Replace stale spec index.html with a browser resolve demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,667 +1,75 @@
 <!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    <title>Nostr DID Method Specification</title>
-    <script
-      src="https://www.w3.org/Tools/respec/respec-w3c"
-      class="remove"
-    ></script>
-    <script class="remove">
-      const respecConfig = {
-        specStatus: 'unofficial',
-        group: 'nostr',
-        subtitle: 'Version 0.0.7',
-        latestVersion: 'https://nostrcg.github.io/did-nostr/',
-        editors: [
-          {
-            name: 'Melvin Carvalho',
-            url: 'https://melvincarvalho.com/#me'
-          }
-        ],
-        authors: [
-          {
-            name: 'Melvin Carvalho',
-            url: 'https://melvincarvalho.com/#me'
-          }
-        ],
-        shortName: 'did-nostr',
-        github: 'https://github.com/nostrcg/did-nostr',
-        logos: [
-          {
-            src: 'https://avatars.githubusercontent.com/u/131810998?s=200&v=4',
-            url: 'https://avatars.githubusercontent.com/u/131810998?s=200&v=4',
-            alt: 'W3C Nostr CG',
-            width: 100,
-            height: 100,
-            id: 'w3c-nostr'
-          }
-        ],
-        lint: {
-          "no-unused-dfns": false
-        }
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>did:nostr resolver</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body { font: 15px/1.55 system-ui, sans-serif; max-width: 760px; margin: 2rem auto; padding: 0 1rem; }
+    h1 { font-size: 1.4rem; margin-bottom: .25rem; }
+    .meta { color: #888; font-size: .85rem; }
+    .row { display: flex; gap: .5rem; margin: .75rem 0; flex-wrap: wrap; align-items: center; }
+    input[type=text] { flex: 1; min-width: 16rem; padding: .5rem .6rem; font: inherit; }
+    button { padding: .5rem 1rem; font: inherit; cursor: pointer; }
+    fieldset { border: 1px solid #8884; border-radius: 6px; }
+    legend { padding: 0 .4rem; }
+    pre { background: #8881; padding: 1rem; border-radius: 6px; overflow: auto; white-space: pre-wrap; word-break: break-all; }
+    a { color: inherit; }
+  </style>
+</head>
+<body>
+  <h1>did:nostr resolver</h1>
+  <p class="meta">
+    Browser demo of the <a href="https://www.npmjs.com/package/did-nostr">did-nostr</a> resolver.
+    Spec: <a href="https://nostrcg.github.io/did-nostr/">nostrcg.github.io/did-nostr</a> ·
+    Source: <a href="https://github.com/melvincarvalho/did-nostr">GitHub</a>
+  </p>
+
+  <div class="row">
+    <input id="did" type="text" placeholder="did:nostr:&lt;64-hex&gt; or a 64-hex pubkey"
+      value="did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2" />
+    <button id="go">Resolve</button>
+  </div>
+
+  <fieldset class="row">
+    <legend>mode</legend>
+    <label><input type="radio" name="mode" value="auto" checked> auto</label>
+    <label><input type="radio" name="mode" value="offline"> offline</label>
+    <label><input type="radio" name="mode" value="http"> http (.well-known)</label>
+    <label><input type="radio" name="mode" value="relay"> relay</label>
+  </fieldset>
+
+  <pre id="out">…</pre>
+  <p class="meta" id="note"></p>
+
+  <p class="meta">
+    <strong>offline</strong> needs no network · <strong>http</strong> depends on the gateway sending CORS headers ·
+    <strong>relay</strong> queries public relays over WebSocket.
+  </p>
+
+  <script type="module">
+    import { resolve } from './src/index.js';
+    const $ = (id) => document.getElementById(id);
+    const out = $('out'), note = $('note');
+
+    async function run() {
+      const did = $('did').value.trim();
+      const mode = document.querySelector('input[name=mode]:checked').value;
+      out.textContent = 'resolving…';
+      note.textContent = '';
+      try {
+        const result = await resolve(did, { mode, gateways: ['https://nostr.social'] });
+        out.textContent = JSON.stringify(result.didDocument ?? result, null, 2);
+        const m = result.didResolutionMetadata || {};
+        note.textContent = m.error ? `error: ${m.error}` : `resolved via: ${m.mode || mode}`;
+      } catch (e) {
+        out.textContent = String((e && e.message) || e);
       }
-    </script>
-  </head>
-  <body>
-    <section id="abstract">
-      <p>
-        This specification defines a Decentralized Identifier (DID)[[DID-CORE]]
-        method for the Nostr <a href="https://github.com/nostr-protocol/nostr">protocol</a>. Nostr is
-        an open-source protocol that utilizes the W3C WebSockets standard.
-      </p>
-    </section>
-    <section id="sotd">
-      <p>
-        This document is a draft specification produced by the <a href="https://www.w3.org/community/nostr/">W3C Nostr Community Group</a>. 
-        It is not a W3C Standard nor is it on the W3C Standards Track.
-      </p>
-      <p>
-        This specification is intended to provide a stable foundation for implementing Nostr-based Decentralized Identifiers. 
-        Feedback and contributions are encouraged through the <a href="https://github.com/nostrcg/did-nostr">GitHub repository</a>.
-      </p>
-      <p>
-        This document is a work in progress and may be updated, replaced, or obsoleted by other documents at any time.
-        It is inappropriate to cite this document as other than work in progress.
-      </p>
-    </section>
-    
-    <!-- introduction -->
-    <section class="informative">
-      <h2>Introduction</h2>
-      <p>
-        Decentralized Identifiers (DIDs) are a new type of identifier that enables verifiable, decentralized digital identity. 
-        The Nostr DID method connects the emerging W3C DID standard with the Nostr protocol, allowing Nostr keypairs to be 
-        used as the foundation for decentralized identifiers.
-      </p>
-      <p>
-        Nostr is a simple, open protocol that enables a truly censorship-resistant and global social network. By creating a 
-        DID method for Nostr, this specification enables Nostr identities to participate in the broader decentralized identity 
-        ecosystem, supporting verifiable credentials, authentication, and other identity use cases.
-      </p>
-      <p>
-        This specification describes how to create, read, and use Nostr DIDs, along with the expected behavior 
-        of conforming implementations. The method is designed to be simple, requiring minimal processing overhead 
-        while maintaining compatibility with existing Nostr tooling and infrastructure.
-      </p>
-    </section>
-    <section>
-      <h2>Core Concepts</h2>
-      <section>
-        <h3>Nostr DID Scheme</h3>
-        <p>
-          The Nostr DID scheme `did:nostr:pubkey` is based on the encoding of a
-          public key. The public key is represented as a 64-character, lowercase
-          string. The prefix <code>did:nostr</code> should be in lowercase, as
-          per the DID specification.
-        </p>
-
-        <p>
-          All DID documents MUST include a <code>type</code> field with the value <code>"DIDNostr"</code> 
-          to enable proper linked data processing and disambiguation per httpRange-14.
-        </p>
-
-        <p>
-          Example Nostr DID:
-          <code
-            >did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2</code
-          >.
-        </p>
-      </section>
-
-      <section>
-        <h3>Relationship with Nostr npubs</h3>
-        <p>
-          In the Nostr ecosystem, public keys are often displayed as "npubs" (e.g., <code>npub1...</code>), 
-          which are Bech32 encoded versions of the raw public keys for human-friendly display.
-        </p>
-        
-        <p>
-          It is important to note that Nostr DIDs use the raw 64-character hexadecimal public key, 
-          not the npub format. npubs should be considered display-only identifiers to improve readability 
-          in user interfaces.
-        </p>
-
-        <p>
-          When implementing the DID Nostr method, applications SHOULD accept raw public keys for 
-          DID creation. For display in user interfaces, applications MAY choose to show the 
-          corresponding npub alongside the DID.
-        </p>
-
-        <p>
-          Example mapping:
-          <ul>
-            <li>Raw public key: <code>124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2</code></li>
-            <li>DID: <code>did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2</code></li>
-            <li>Display npub: <code>npub1cpxejnc58zpcuyh0pt8gvkzpv34qxceu0sqp7jec2nk9nut7p5zs4zyx4c</code></li>
-          </ul>
-        </p>
-      </section>
-
-      <section>
-        <h3>Example DID Documents</h3>
-        
-        <section>
-          <h4>Minimal DID Document (Offline Resolution)</h4>
-          <p>The following minimal DID document can be generated from the public key alone, without network access:</p>
-          <pre class="example">
-{
-    "@context": ["https://w3id.org/did", "https://w3id.org/nostr/context"],
-    "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
-    "type": "DIDNostr",
-    "verificationMethod": [
-        {
-            "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2#key1",
-            "type": "Multikey",
-            "controller": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
-            "publicKeyMultibase": "fe70102124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2"
-        }
-    ],
-    "authentication": ["#key1"],
-    "assertionMethod": ["#key1"]
-}
-  </pre>
-          <p>This minimal document provides full cryptographic functionality for identity verification and authentication using the standardized Multikey format.</p>
-        </section>
-        
-        <section>
-          <h4>Enhanced DID Document (With Relay Services)</h4>
-          <p>When enhanced through relay queries, additional service endpoints can be included:</p>
-          <pre class="example">
-{
-    "@context": ["https://w3id.org/did", "https://w3id.org/nostr/context"],
-    "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
-    "type": "DIDNostr",
-    "verificationMethod": [
-        {
-            "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2#key1",
-            "type": "Multikey",
-            "controller": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
-            "publicKeyMultibase": "fe70102124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2"
-        }
-    ],
-    "authentication": ["#key1"],
-    "assertionMethod": ["#key1"],
-    "service": [
-        {
-            "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2#relay1",
-            "type": "Relay",
-            "serviceEndpoint": "wss://some-nostr-relay.org/"
-        }
-    ]
-}
-  </pre>
-          <p>This enhanced document includes service endpoints discovered through optional relay queries.</p>
-        </section>
-
-        <section>
-          <h4>Complete DID Document (With Profile and Social Graph)</h4>
-          <p>A fully enhanced DID document can include profile information and social relationships:</p>
-          <pre class="example">
-{
-    "@context": ["https://w3id.org/did", "https://w3id.org/nostr/context"],
-    "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
-    "type": "DIDNostr",
-    "verificationMethod": [
-        {
-            "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2#key1",
-            "type": "Multikey",
-            "controller": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
-            "publicKeyMultibase": "fe70102124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2"
-        }
-    ],
-    "authentication": ["#key1"],
-    "assertionMethod": ["#key1"],
-    "service": [
-        {
-            "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2#relay1",
-            "type": "Relay",
-            "serviceEndpoint": "wss://relay.damus.io/"
-        }
-    ],
-    "profile": {
-        "name": "Alice", 
-        "about": "Building the decentralized web",
-        "picture": "https://example.com/alice.jpg",
-        "timestamp": 1737906600
-    },
-    "follows": [
-        "did:nostr:32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245",
-        "did:nostr:46fcbe3065eaf1ae7811465924e48923363ff3f526bd6f73d7c184147700e3a8"
-    ]
-}
-  </pre>
-          <p>This complete document enables social applications to resolve identity, profile, relays, and social graph information in a single operation.</p>
-          <p>
-            For identities with large follow lists, the service array could include a FollowsEndpoint 
-            for complete access to thousands of follows without bloating the DID document.
-          </p>
-        </section>
-      </section>
-      <section>
-        <h3>Additional Terminology</h3>
-        <p>The term <dfn class="export">relay</dfn> refers to a Nostr relay.</p>
-      </section>
-
-      <section>
-        <h3>Multikey Verification Method</h3>
-        <p>
-          Nostr DIDs use the Multikey verification method to provide a standardized way to encode 
-          secp256k1 public keys for Data Integrity implementations. This method transforms the x-only 
-          BIP-340 public key from the DID identifier into a format compatible with W3C Verifiable 
-          Credentials Data Integrity specifications.
-        </p>
-        
-        <p>
-          The transformation process for creating the Multikey representation is as follows:
-        </p>
-        
-        <ol>
-          <li>Start with the x-only public key (32 bytes) from the DID identifier</li>
-          <li>Construct a 33-byte secp256k1 compressed public key by prepending a parity byte:
-            <ul>
-              <li>Use <code>0x02</code> for even y-coordinate (standard default)</li>
-              <li>Use <code>0x03</code> for odd y-coordinate (when applicable for Nostr keys)</li>
-            </ul>
-          </li>
-          <li>Prepend the multicodec varint for secp256k1 compressed public keys (<code>0xe7, 0x01</code>)</li>
-          <li>Encode the result using multibase with base16-lower encoding (<code>f</code> prefix)</li>
-          <li>Place the encoded value in the <code>publicKeyMultibase</code> field</li>
-        </ol>
-        
-        <p>
-          For example, given the x-only public key:
-          <code>124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2</code>
-        </p>
-        
-        <p>
-          The transformation steps would be:
-        </p>
-        <ol>
-          <li>Compressed key: <code>02124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2</code></li>
-          <li>With multicodec varint: <code>e70102124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2</code></li>
-          <li>Multibase base16-lower encoded: <code>fe70102124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2</code></li>
-        </ol>
-        
-        <p>
-          <strong>Note on Parity Bytes:</strong> While most implementations default to the 0x02 prefix 
-          for even y-coordinates, Nostr applications may generate keys with either 0x02 or 0x03 prefixes. 
-          Implementations should handle both cases when constructing the compressed public key format.
-        </p>
-      </section>
-
-      <section>
-        <h3>Service Field for Relays</h3>
-        <p>
-          The DID Document SHOULD include a service field to explicitly define
-          relevant relays. This provides a standardized approach for
-          applications resolving a DID document to discover the relays
-          associated with the identity.
-        </p>
-        <p>
-          Each relay is represented as a service entry with type "Relay" and a
-          serviceEndpoint that specifies the WebSocket URL of the relay.
-          Relay URLs at the origin level MUST include a trailing slash (e.g., <code>wss://relay.example.com/</code>).
-          Multiple relays can be included in the service array.
-        </p>
-      </section>
-      
-      <section>
-        <h3>Profile Field (Optional)</h3>
-        <p>
-          DID Documents MAY include a <code>profile</code> field containing public profile information 
-          that the user has chosen to share. This enables social applications to display profile 
-          information without requiring relay queries.
-        </p>
-        <pre class="example">
-"profile": {
-    "name": "Alice",
-    "about": "Building the decentralized social web",
-    "picture": "https://example.com/alice.jpg",
-    "nip05": "alice@example.com",
-    "lud16": "alice@getalby.com",
-    "website": "https://alice.example.com",
-    "timestamp": 1737906600
-}</pre>
-        <p>
-          The <code>timestamp</code> field contains the <code>created_at</code> value from the latest Nostr profile event (Unix seconds), 
-          allowing clients to determine profile freshness and implement intelligent caching strategies.
-        </p>
-        <p>
-          <strong>Note:</strong> For Nostr developers: the <code>timestamp</code> field contains the same value as 
-          <code>event.created_at</code> from the most recent kind 0 profile event. This allows clients to determine 
-          if their cached profile data is newer or older than what's in the DID document without querying relays.
-        </p>
-        <p>
-          <strong>Note:</strong> While DID Core generally recommends against including personally identifiable information, 
-          social networking represents a specific use case where users explicitly publish profile information for 
-          discovery. This field is optional and should only contain information the user has chosen to make public.
-        </p>
-      </section>
-
-      <section>
-        <h3>Follows Field (Social Graph)</h3>
-        <p>
-          DID Documents MAY include a <code>follows</code> field containing a list of DIDs that the identity follows,
-          enabling the construction of decentralized social graphs. This field enhances the DID document with 
-          social relationship information discoverable through standard DID resolution.
-        </p>
-        <pre class="example">
-"follows": [
-    "did:nostr:32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245",
-    "did:nostr:46fcbe3065eaf1ae7811465924e48923363ff3f526bd6f73d7c184147700e3a8",
-    "did:nostr:82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"
-]</pre>
-        <p>
-          Each entry in the follows array is a DID that represents an identity this DID follows.
-          The follows field is derived from Nostr kind 3 "contact list" events, providing a standardized
-          way to expose social graph relationships through DID resolution.
-        </p>
-        <p>
-          The <code>follows</code> field enables applications to:
-        </p>
-        <ul>
-          <li>Build social graphs from DID resolution alone</li>
-          <li>Discover mutual connections between identities</li>
-          <li>Implement social discovery features</li>
-          <li>Cache social relationships for offline operation</li>
-        </ul>
-        <p>
-          <strong>Note:</strong> The follows field mirrors the public contact list already published in 
-          Nostr kind 3 events, making this social graph data available through standard DID resolution.
-        </p>
-        <p>
-          <strong>Scalability Consideration:</strong> For identities with large follow lists (thousands of follows),
-          implementations SHOULD use a hybrid approach:
-        </p>
-        <ul>
-          <li>Include a truncated list (e.g., first 100-500 most recent follows)</li>
-          <li>Provide a service endpoint for complete follow list retrieval</li>
-        </ul>
-        <pre class="example">
-"follows": [
-    "did:nostr:32e182...",  // First 100 follows included
-    "did:nostr:46fcbe...",
-    // ... up to 100 entries
-],
-"service": [
-    {
-        "id": "#follows-api",
-        "type": "FollowsEndpoint",
-        "serviceEndpoint": "https://api.example.com/did/follows/{did}"
     }
-]</pre>
-        <p>
-          This hybrid approach provides immediate access to recent follows while maintaining 
-          document size limits and offering complete data access when needed. This pattern 
-          addresses the scalability challenge shared with other social protocols like ActivityPub.
-        </p>
-      </section>
-    </section>
-    <section id="conformance">
-      <p>
-        This document defines a DID method for Nostr. Implementations MUST conform to the DID Core
-        specification [[DID-CORE]] and the requirements specified in this document.
-      </p>
-    </section>
-    <section>
-      <h2>Operations</h2>
-      <section>
-        <h3>Create (Register)</h3>
-        <p>
-          Creating a did:nostr identifier involves the following steps:
-        </p>
-        <ol>
-          <li>Generate a secp256k1 key pair using a cryptographically secure random number generator</li>
-          <li>Extract the public key (32 bytes)</li>
-          <li>Encode the public key as a 64-character lowercase hexadecimal string</li>
-          <li>Prefix the encoded public key with "did:nostr:" to form the complete DID</li>
-        </ol>
-        <p>
-          For example, if the generated public key in hex is:<br>
-          <code>124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2</code>
-        </p>
-        <p>
-          The corresponding DID would be:<br>
-          <code>did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2</code>
-        </p>
-        <p>
-          Note: No on-chain registration is required as the security and uniqueness are derived from the key generation process.
-        </p>
-      </section>
-
-      <section>
-        <h3>Read (Resolve)</h3>
-        
-        <p>DID resolution for <code>did:nostr</code> identifiers follows this strategy:</p>
-        
-        <ol>
-          <li><strong>HTTP Resolution</strong> - Check <code>https://&lt;domain&gt;/.well-known/did/nostr/&lt;pubkey&gt;.json</code></li>
-          <li><strong>Offline-first Resolution</strong> - Generate minimal DID document from public key alone</li>
-          <li><strong>Enhanced Resolution</strong> - Optionally query Nostr relays for additional metadata</li>
-        </ol>
-        
-        <section>
-          <h4>HTTP Resolution</h4>
-          <p>
-            Servers can host complete DID documents at:
-          </p>
-          <pre><code>https://example.com/.well-known/did/nostr/&lt;pubkey&gt;.json</code></pre>
-          <p>
-            Where <code>&lt;pubkey&gt;</code> is the 64-character lowercase hex public key. The endpoint SHOULD return a complete DID document (minimal or enhanced).
-          </p>
-          <p>
-            When serving DID documents via HTTP, servers SHOULD include the following headers:
-          </p>
-          <pre><code>Nostr-Timestamp: 1737906600
-Cache-Control: max-age=3600
-Last-Modified: Sun, 26 Jan 2025 15:30:00 GMT</code></pre>
-          <p>
-            The <code>Nostr-Timestamp</code> header contains the Unix timestamp when the DID document was generated or refreshed. This enables clients to check freshness without parsing the JSON body, allowing for efficient caching strategies.
-          </p>
-          <p>
-            This enables fast, cacheable resolution without requiring cryptographic computation or relay queries. Servers can serve minimal documents for offline-first scenarios or enhanced documents with service endpoints and profile metadata.
-          </p>
-          <p>
-            <strong>Note:</strong> Resolvers MAY check NIP-05 endpoints for a <code>didResolver</code> field to locate HTTP-hosted DID documents before querying relays.
-          </p>
-        </section>
-        
-        <section>
-          <h4>Minimal Resolution</h4>
-          <p>
-            A conforming resolver MUST be able to generate a valid DID document using only the public key from the DID identifier, without requiring network access to Nostr relays.
-          </p>
-          <p>
-            The minimal resolution process involves:
-          </p>
-          <ol>
-            <li>Parse the identifier to extract the 64-character hexadecimal public key</li>
-            <li>Construct a DID Document with the following required properties:
-              <ul>
-                <li>Set the <code>id</code> field to the full DID</li>
-                <li>Set the <code>type</code> field to <code>"DIDNostr"</code></li>
-                <li>Include a Multikey verification method, transforming the x-only public key following the multicodec/multibase encoding process</li>
-                <li>Set appropriate authentication and assertionMethod references to the verification method</li>
-              </ul>
-            </li>
-          </ol>
-          <p>
-            This minimal DID document provides full functionality for cryptographic verification and identity assertion without requiring network connectivity.
-          </p>
-        </section>
-        
-        <section>
-          <h4>Enhanced Resolution with Relay Queries</h4>
-          <p>
-            Optionally, resolvers MAY query known Nostr relays to enhance the DID document with additional metadata and service endpoints.
-          </p>
-          <p>
-            The enhanced resolution process adds:
-          </p>
-          <ol>
-            <li>Query known Nostr relays for metadata about the public key</li>
-            <li>Include discovered relay endpoints in the service section of the DID Document</li>
-            <li>Add any additional metadata found in kind 0 (profile) events</li>
-            <li>Include social graph information from kind 3 (contact list) events in the follows field</li>
-          </ol>
-          <p>
-            The resolved DID Document will follow the template shown in the "Example DID" section above.
-          </p>
-        </section>
-        <p>
-          For relay discovery during enhanced resolution, implementations SHOULD:
-        </p>
-        <ol>
-          <li>Check a local cache of known relays for the public key</li>
-          <li>Query a set of default relays with a filter for kind 0 (metadata) and kind 3 (contact list) events by the target public key</li>
-          <li>Include discovered relays in the service section of the DID Document</li>
-          <li>Transform kind 3 contact pubkeys to DIDs and include in the follows field</li>
-        </ol>
-        <p>
-          Note that relay queries and metadata integration are OPTIONAL enhancements to the basic resolution process. Implementations MUST support minimal resolution without network access.
-        </p>
-      </section>
-
-      <section>
-        <h3>Update (Replace)</h3>
-        <p>This DID Method does not support updating the DID Document.</p>
-      </section>
-
-      <section>
-        <h3>Delete (Revoke)</h3>
-        <p>
-          This DID Method does not support deactivating the DID Document.
-        </p>
-      </section>
-    </section>
-
-    <section>
-      <h2>Security & Privacy</h2>
-      <section>
-        <h3>Security Considerations</h3>
-        <p>
-          The security of the did:nostr method relies on the security properties of the underlying Nostr protocol and its 
-          public key cryptography. The following security considerations apply:
-        </p>
-        
-        <section>
-          <h4>Key Management</h4>
-          <p>
-            The private keys corresponding to Nostr DIDs MUST be kept secure. Loss of private keys will result in permanent 
-            loss of control over the identifier. Implementers SHOULD employ strong key management practices, including 
-            secure key generation, storage, and backup procedures.
-          </p>
-        </section>
-        
-        <section>
-          <h4>Relay Security</h4>
-          <p>
-            Nostr DIDs interact with the Nostr network through relays. These relays may have different security 
-            properties and trust models. Implementers SHOULD:
-          </p>
-          <ul>
-            <li>Use TLS (wss://) connections to relays to prevent eavesdropping and man-in-the-middle attacks</li>
-            <li>Consider using multiple relays for redundancy and to mitigate denial of service risks</li>
-            <li>Be aware that relays may choose to filter or modify events, potentially affecting DID resolution</li>
-          </ul>
-        </section>
-        
-        <section>
-          <h4>Cryptographic Considerations</h4>
-          <p>
-            The Nostr DID method uses Schnorr signatures over the secp256k1 curve, which is considered cryptographically 
-            secure at the time of writing. However, cryptographic methods may become vulnerable over time. Implementers 
-            should stay informed about advancements in cryptanalysis that might affect the security of these signatures.
-          </p>
-        </section>
-        
-        <p>
-          For additional security requirements, refer to 
-          <a href="https://www.w3.org/TR/did-core/#security-requirements">
-            W3C Decentralized Identifiers 8.3</a>.
-        </p>
-      </section>
-      <section>
-        <h3>Privacy Considerations</h3>
-        <p>
-          The did:nostr method has several privacy implications that implementers and users should be aware of:
-        </p>
-        
-        <section>
-          <h4>Identifier Correlation</h4>
-          <p>
-            A Nostr DID directly incorporates a public key that may be used across multiple contexts in the Nostr ecosystem. 
-            This creates a potential correlation vector where activities under the same DID can be linked across different 
-            services or applications. Users should understand that a single did:nostr identifier does not provide 
-            compartmentalization of identity across different contexts.
-          </p>
-          <p>
-            To mitigate correlation risks, users may consider:
-          </p>
-          <ul>
-            <li>Using different DIDs for different contexts or services</li>
-            <li>Creating purpose-specific DIDs rather than using a single DID for all activities</li>
-          </ul>
-        </section>
-        
-        <section>
-          <h4>Public Nature of Nostr</h4>
-          <p>
-            Information associated with a Nostr DID is typically stored on public relays where it can be accessed by anyone. 
-            Users should be aware that DID Documents and associated Nostr events are public information. Private or sensitive 
-            data should not be included in DID Documents or directly associated with did:nostr identifiers.
-          </p>
-        </section>
-        
-        <section>
-          <h4>Service Endpoints</h4>
-          <p>
-            The service endpoints (relays) listed in a DID Document may reveal information about a user's network 
-            participation and potentially their geographic region or service preferences. Implementers should be 
-            cautious about what information might be inferred from service endpoints included in DID Documents.
-          </p>
-        </section>
-        
-        <p>
-          For additional privacy requirements, refer to 
-          <a href="https://www.w3.org/TR/did-core/#privacy-requirements">
-            W3C Decentralized Identifiers 8.4</a>.
-        </p>
-      </section>
-    </section>
-    <section>
-      <h2>Implementations</h2>
-      <p>
-        Block, Inc. previously developed a related implementation of the did:nostr method in Rust, but this work has been discontinued and archived. The archived repository can be found at
-        <a href="https://github.com/TBD54566975/did-nostr"
-          >https://github.com/TBD54566975/did-nostr</a
-        >.
-      </p>
-    </section>
-
-    <section>
-      <h2>Resources</h2>
-      <ul>
-        <li>
-          <a href="https://github.com/nostr-protocol/nostr">Nostr Protocol Specification</a> - The official specification of the Nostr protocol
-        </li>
-        <li>
-          <a href="https://www.w3.org/TR/did-core/">W3C Decentralized Identifiers (DIDs) v1.0</a> - The W3C Recommendation for Decentralized Identifiers
-        </li>
-        <li>
-          <a href="https://github.com/nostrcg/did-nostr">DID:Nostr Method GitHub Repository</a> - Source code and issue tracker for this specification
-        </li>
-        <li>
-          <a href="https://github.com/TBD54566975/did-nostr">TBD54566975 Rust Implementation</a> - Reference implementation of the did:nostr method in Rust
-        </li>
-        <li>
-          <a href="https://github.com/nostr-protocol/nips">Nostr Implementation Possibilities (NIPs)</a> - Nostr protocol extension proposals
-        </li>
-        <li>
-          <a href="https://www.rfc-editor.org/rfc/rfc6979">RFC 6979</a> - Deterministic Usage of the Digital Signature Algorithm (DSA) and Elliptic Curve Digital Signature Algorithm (ECDSA)
-        </li>
-      </ul>
-    </section>
-  </body>
+    $('go').addEventListener('click', run);
+    $('did').addEventListener('keydown', (e) => { if (e.key === 'Enter') run(); });
+    run();
+  </script>
+</body>
 </html>


### PR DESCRIPTION
The repo's `index.html` was a superseded copy of the spec (canonical spec now lives at nostrcg/did-nostr). Replace it with a small, dependency-free **browser resolve demo** that imports the resolver ESM (`./src/index.js`) directly and resolves a `did:nostr` DID in the browser.

- Paste a DID (or 64-hex pubkey) → see the resolved DID document.
- Mode switch: `auto` / `offline` / `http` (.well-known) / `relay`.
- Offline works with no network; http depends on gateway CORS; relay uses WebSocket.

Uses the `gh-pages` branch as a live demo page for the resolver.