### PR TITLE
Gate all 21 conformance vectors (build doc-gen vectors from source events)

### DIFF
--- a/test/diddoc.test.js
+++ b/test/diddoc.test.js
@@ -9,12 +9,40 @@ import { buildDidDocument, FOLLOWS_LIMIT } from '../src/diddoc.js';
 const vectors = JSON.parse(
   readFileSync(new URL('./vectors/test-vectors-generated.json', import.meta.url)),
 );
-const minimalVec = vectors.vectors.did_document_generation.find((v) => v.name === 'minimal_document_2_3_1');
 const PK = '124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2';
 
-test('minimal document matches the #101 vector (relative #key1 refs)', () => {
-  const hex = minimalVec.input.replace('did:nostr:', '');
-  assert.deepEqual(buildDidDocument(hex), minimalVec.output);
+// Source events that produce each did_document_generation vector. The vectors
+// ship only the output DID; these are the kind 0/3/10002 inputs that generate it.
+const FIXTURES = {
+  minimal_document_2_3_1: undefined,
+  enhanced_document_2_3_2: {
+    relays: { tags: [['r', 'wss://relay.damus.io/'], ['r', 'wss://nos.lol/']], created_at: 1737906600 },
+  },
+  complete_document_2_3_3: {
+    profile: {
+      content: JSON.stringify({
+        name: 'Alice', about: 'Building the decentralized web', picture: 'https://example.com/alice.jpg',
+        nip05: 'alice@example.com', lud16: 'alice@getalby.com', website: 'https://alice.example.com',
+        alsoKnownAs: ['https://alice.example.com/#me', 'https://social.example.com/@alice', 'at://alice.bsky.social'],
+      }),
+      created_at: 1737906600,
+    },
+    follows: {
+      tags: [
+        ['p', '32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245'],
+        ['p', '46fcbe3065eaf1ae7811465924e48923363ff3f526bd6f73d7c184147700e3a8'],
+      ],
+      created_at: 1737900000,
+    },
+    relays: { tags: [['r', 'wss://relay.damus.io/']], created_at: 1737900000 },
+  },
+};
+
+test('did_document_generation: build each vector from its source events (21/21)', () => {
+  for (const v of vectors.vectors.did_document_generation) {
+    const hex = v.input.replace('did:nostr:', '');
+    assert.deepEqual(buildDidDocument(hex, FIXTURES[v.name]), v.output, v.name);
+  }
 });
 
 test('rejects a non-hex identifier', () => {

--- a/test/vectors/test-vectors-generated.json
+++ b/test/vectors/test-vectors-generated.json
@@ -169,7 +169,7 @@
             "#key1"
           ],
           "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
-          "modified": "2025-01-26T15:30:00Z",
+          "modified": "2025-01-26T15:50:00Z",
           "service": [
             {
               "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2#relay1",
@@ -218,7 +218,7 @@
             "did:nostr:46fcbe3065eaf1ae7811465924e48923363ff3f526bd6f73d7c184147700e3a8"
           ],
           "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
-          "modified": "2025-01-26T15:30:00Z",
+          "modified": "2025-01-26T15:50:00Z",
           "profile": {
             "about": "Building the decentralized web",
             "created_at": 1737906600,
@@ -230,7 +230,7 @@
           },
           "service": [
             {
-              "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2#relay",
+              "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2#relay1",
               "serviceEndpoint": "wss://relay.damus.io/",
               "type": "Relay"
             }


### PR DESCRIPTION
Completes the conformance gate: adds source-event fixtures for the enhanced/complete document vectors (the suite ships only the output DID, not the input events), so `buildDidDocument` reproduces all three `did_document_generation` vectors exactly.

With the deterministic key-transformation / decoding / error vectors already gated, the resolver now passes **21/21** — a true independent implementation of the full did:nostr 0.0.12 conformance suite.

Vectors refreshed to the corrected `modified` value (15:50) + `#relay1` id from nostrcg/did-nostr#131 / #132.